### PR TITLE
Fix issues with the unit tests

### DIFF
--- a/host/aes_crypto.c
+++ b/host/aes_crypto.c
@@ -133,6 +133,7 @@ TEE_AES_ctr128_encrypt(const unsigned char* in_data,
   uint32_t blockOffset = *num;
   uint32_t len = length;
   TEEC_SharedMemory g_outm;
+  uint8_t temp[16];
 
   if (!key || !out_data || !num || !iv)
     return EINVAL;
@@ -202,6 +203,7 @@ TEE_AES_ctr128_encrypt(const unsigned char* in_data,
   /* TA Key */
   op.params[PARAM_AES_KEY].memref.parent = &g_key;
   op.params[PARAM_AES_KEY].memref.size =  CTR_AES_KEY_SIZE;
+  memcpy(temp, out_data + offset - blockOffset, blockOffset);
 
   res = TEEC_InvokeCommand(&sess, TA_AES_CTR128_ENCRYPT, &op,
          &err_origin);
@@ -211,6 +213,8 @@ TEE_AES_ctr128_encrypt(const unsigned char* in_data,
   ion_map_and_memcpy(out_data + offset, length, secure_fd, blockOffset);
   close(secure_fd);
 #endif
+
+  memcpy(out_data + offset - blockOffset, temp, blockOffset);
 
   if(length + blockOffset > 16)
     len = length + blockOffset;

--- a/tests/AesCtrDecryptorUnittest.cpp
+++ b/tests/AesCtrDecryptorUnittest.cpp
@@ -94,7 +94,7 @@ class AesCtrDecryptorTest : public ::testing::Test {
                     opensslIv, previousEncryptedCounter,
                     &blockOffset);
 #else
-            TEE_AES_ctr128_encrypt(source + offset, destination + offset,
+            TEE_AES_ctr128_encrypt(source, destination,
                     subSample.mNumBytesOfEncryptedData, (const char*)keyVector.array(),
                     opensslIv, previousEncryptedCounter,
                     &blockOffset, offset, false);

--- a/tests/AesCtrDecryptorUnittest.cpp
+++ b/tests/AesCtrDecryptorUnittest.cpp
@@ -42,7 +42,9 @@ const uint8_t kBlockSize = AES_BLOCK_SIZE;
 typedef uint8_t KeyId[kBlockSize];
 typedef uint8_t Iv[kBlockSize];
 
+#ifndef USE_AES_TA
 static const size_t kBlockBitCount = kBlockSize * 8;
+#endif
 
 typedef android::CryptoPlugin::SubSample SubSample;
 


### PR DESCRIPTION
kBlockBitCount may issue an unused variable warning which might prevent successful compilation

Fix invocation of encrypt function allowing the tests to run to the end